### PR TITLE
ci: run on latest Ubuntu version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
After some time, GitHub removes older Ubuntu versions. This project does not have many dependencies. Hence, breakage between Ubuntu versions is less probable than running out of a version being provided by GitHub again.

Thus, it makes sense to choose ubuntu-latest.